### PR TITLE
PR: Requesting fix for Boolean variable

### DIFF
--- a/src/createZodSchema.ts
+++ b/src/createZodSchema.ts
@@ -58,6 +58,9 @@ export const parseRules = (rules: Rules, onlyPrimitive: boolean = false) => {
             }
             field = { name: "nonnegative" };
             break;
+	  			case 'boolean':
+	    				field = { name: 'boolean' };
+	    				break;
           case "nullable":
             field = { name: "nullable" };
             break;

--- a/src/createZodSchema.ts
+++ b/src/createZodSchema.ts
@@ -58,9 +58,9 @@ export const parseRules = (rules: Rules, onlyPrimitive: boolean = false) => {
             }
             field = { name: "nonnegative" };
             break;
-	  			case 'boolean':
-	    				field = { name: 'boolean' };
-	    				break;
+          case "boolean":
+            field = { name: "boolean" };
+            break;
           case "nullable":
             field = { name: "nullable" };
             break;


### PR DESCRIPTION
Currently `boolean` variables from **FormRequest** are converted to `z.string()` in zod schema
Fixed to correctly type as `z.boolean()`