### PR TITLE
Fix: Glob Error, and nullable order, Add: stringURL

### DIFF
--- a/src/createZodSchema.ts
+++ b/src/createZodSchema.ts
@@ -26,7 +26,6 @@ export const parseRules = (rules: Rules, onlyPrimitive: boolean = false) => {
     })
     return rule;
   })
-  console.log(sortedRules);
   const parsedRules: ParsedRules = sortedRules.reduce(
     (acc, [key, value]) => {
       const newValue: Field[] = [];

--- a/src/createZodSchema.ts
+++ b/src/createZodSchema.ts
@@ -41,6 +41,12 @@ export const parseRules = (rules: Rules, onlyPrimitive: boolean = false) => {
               newValue.unshift({ name: "date" });
             }
             break;
+          case "url":
+            field = { name: "url" };
+            if (!newValue.find((v) => v.name === "string")) {
+              newValue.unshift({ name: "string" });
+            }
+            break;
           case "email":
             field = { name: "email" };
             if (!newValue.find((v) => v.name === "string")) {
@@ -133,9 +139,9 @@ const createZodChainingRules = (rules: Field[], coercion: boolean = false) => {
   let property: CallExpression | Identifier | PropertyAccessExpression =
     coercion && firstField && isPrimitive(firstField.name)
       ? ts.factory.createPropertyAccessExpression(
-          ts.factory.createIdentifier("z"),
-          ts.factory.createIdentifier("coerce")
-        )
+        ts.factory.createIdentifier("z"),
+        ts.factory.createIdentifier("coerce")
+      )
       : ts.factory.createIdentifier("z");
   rules.forEach((rule) => {
     property = ts.factory.createCallExpression(
@@ -146,10 +152,10 @@ const createZodChainingRules = (rules: Field[], coercion: boolean = false) => {
       undefined,
       rule.param
         ? [
-            typeof rule.param === "number"
-              ? ts.factory.createNumericLiteral(rule.param)
-              : ts.factory.createStringLiteral(rule.param),
-          ]
+          typeof rule.param === "number"
+            ? ts.factory.createNumericLiteral(rule.param)
+            : ts.factory.createStringLiteral(rule.param),
+        ]
         : []
     );
   });

--- a/src/createZodSchema.ts
+++ b/src/createZodSchema.ts
@@ -58,6 +58,9 @@ export const parseRules = (rules: Rules, onlyPrimitive: boolean = false) => {
             }
             field = { name: "nonnegative" };
             break;
+	  			case 'boolean':
+	    				field = { name: 'boolean' };
+	    				break;
           case "nullable":
             field = { name: "nullable" };
             break;

--- a/src/createZodSchema.ts
+++ b/src/createZodSchema.ts
@@ -18,7 +18,16 @@ export type CreateZodSchemaType = Pick<CLIOptions, "coercion"> & {
 };
 
 export const parseRules = (rules: Rules, onlyPrimitive: boolean = false) => {
-  const parsedRules: ParsedRules = Object.entries(rules).reduce(
+  const sortedRules = Object.entries(rules).map(rule => {
+    rule[1] = rule[1].sort((a, b) => {
+      if (a == 'nullable') { return 1; }
+      if (b == 'nullable') { return -1; }
+      return 0;
+    })
+    return rule;
+  })
+  console.log(sortedRules);
+  const parsedRules: ParsedRules = sortedRules.reduce(
     (acc, [key, value]) => {
       const newValue: Field[] = [];
       let isRequired = false;

--- a/src/createZodSchema.ts
+++ b/src/createZodSchema.ts
@@ -58,9 +58,9 @@ export const parseRules = (rules: Rules, onlyPrimitive: boolean = false) => {
             }
             field = { name: "nonnegative" };
             break;
-	  			case 'boolean':
-	    				field = { name: 'boolean' };
-	    				break;
+          case "boolean":
+            field = { name: "boolean" };
+            break;
           case "nullable":
             field = { name: "nullable" };
             break;

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -2,7 +2,7 @@ import { CLIOptions } from "./types";
 import path from "path";
 import { getRules } from "./getRules";
 import fs from "fs";
-import glob from "glob";
+import { sync } from "glob";
 import {
   createZodSchema,
   ParsedRules,
@@ -16,7 +16,7 @@ export function parseFormRequests(formRequestPath: string, onlyPrimitive: boolea
   const parsedFormRequestsPath = path
     .join(formRequestPath, "**", "*.php")
     .replace(/\\/g, "/");
-  const formRequests = glob.sync(parsedFormRequestsPath);
+  const formRequests = sync(parsedFormRequestsPath);
   const rules: { [key: string]: Rules } = formRequests.reduce(
     (acc, formRequest) => ({
       ...acc,


### PR DESCRIPTION
Fixed error: `The requested module 'glob' does not provide an export named 'default'`

Fixed Ordering of nullable: 
- original: (rulles cannot follow nullable in zod)
![image](https://github.com/7nohe/laravel-zodgen/assets/70946464/1c29fb0a-a581-4948-a86b-8f2ce2121b32)

- fix: (nullable automatically added as last rule)
![image](https://github.com/7nohe/laravel-zodgen/assets/70946464/dbd8f354-9dd1-410e-b602-437369a54d4a)

Added URL rule
![image](https://github.com/7nohe/laravel-zodgen/assets/70946464/469ae531-39a9-4ff5-b176-fc6682f55fb0)
